### PR TITLE
Add support for specific formating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ OPTIONS := --trace \
   -a revdate=${DATE} \
   -a imagesoutdir=${BUILD_DIR}/images \
   -a pdf-fontsdir=docs-resources/fonts \
-  -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
+  -a pdf-theme=src/wp-theme.yml \
   $(XTRA_ADOC_OPTS) \
   -D ${BUILD_DIR} \
   --failure-level=ERROR

--- a/src/chapters/caches.adoc
+++ b/src/chapters/caches.adoc
@@ -23,9 +23,9 @@ issues:
 * The implicit nature of the memory access through a cache memory, while very
 convenient from a programming point of view (for non-safety-critical systems),
 means there is little control over the transaction.
-Dedicated instructions such as the CMO extensions or memory fences that may be
-needed to ensure consistency (especially in a copy-back cache) are usually not
-exposed in higher-level programming languages.
+Dedicated instructions such as the [.extension]#CMO# extensions or memory fences
+that may be needed to ensure consistency (especially in a copy-back cache) are
+usually not exposed in higher-level programming languages.
 * While the average memory access time is reduced, variability of access time is
 increased.
 Multiple accesses to the same memory location may have widely differing access
@@ -270,11 +270,10 @@ non-cacheable.
 This scheme may be either fixed or configurable by Machine Mode Software.
 This satisfies safety requirements for disabling the effect of caches for
 particular data areas (though not through a standardized mechanism).
-For paged virtual-memory systems, if implemented the _Svpbmt_ (Page-Based Memory
-Types) extension (see
-RISC-V Privileged ISA Specification cite:[rv-priv-spec:2024] Chapter 12)
-provides a more suitable and standardized method for achieving the same
-objective.
+For paged virtual-memory systems, if implemented the [.extension]#Svpbmt#
+(Page-Based Memory Types) extension (see RISC-V Privileged ISA Specification
+cite:[rv-priv-spec:2024] Chapter 12) provides a more suitable and standardized
+method for achieving the same objective.
 
 The RISC-V Unprivileged ISA Specification cite:[rv-unpriv-spec:2024] Chapter 17
 defines the RISC-V Weak Memory Ordering model, applied to main memory.
@@ -285,11 +284,12 @@ In the RISC-V Unprivileged ISA Specification cite:[rv-unpriv-spec:2024] Chapter
 19, the Cache Management Operations TG specified instructions to manage a Cache
 Block (with architecture-dependant block size):
 
-* The _Zicbom_ extension defines a set of cache-block management instructions:
-`CBO.INVAL`, `CBO.CLEAN`, and `CBO.FLUSH`
-* The _Zicboz_ extension defines a cache-block zero instruction: `CBO.ZERO`
-* The _Zicbop_ extension defines a set of cache-block prefetch instructions:
-`PREFETCH.R`, `PREFETCH.W`, and `PREFETCH.I`
+* The [.extension]#Zicbom# extension defines a set of cache-block management
+instructions: `CBO.INVAL`, `CBO.CLEAN`, and `CBO.FLUSH`
+* The [.extension]#Zicboz# extension defines a cache-block zero instruction:
+`CBO.ZERO`
+* The [.extension]#Zicbop# extension defines a set of cache-block prefetch
+instructions: `PREFETCH.R`, `PREFETCH.W`, and `PREFETCH.I`
 
 [#sec:caches:recom]
 ### Recommendations
@@ -305,9 +305,9 @@ Alternatively, set/way operations should be supported, which can be used to
 synthesize such entire cache/partition operations.
 +
 The ability to control (clean/invalidate) caches is provided in the (ratified)
-"Base Cache Maintenance Operations” extensions, more specifically the _Zicbom_
-(Cache Block Management) extension.
-These specify “block operations” -- operations related to a particular
+"Cache Management Operations" extensions, more specifically the
+[.extension]#Zicbom# (Cache Block Management) extension.
+These specify "block operations" -- operations related to a particular
 physical address range.
 This mechanism is suitable for implementing a software cache coherency scheme
 in situations where software knows that an external agent (that is not
@@ -316,7 +316,8 @@ operation) or is about to read from (for the clean operation) a specific
 buffer of data.
 However, it is not well suited to resetting the cache to a known state to
 provide the temporal isolation discussed here, as one can expect the size of
-a _Zicbom_ block to be too small to effectively use the entire address space.
+a [.extension]#Zicbom# block to be too small to effectively use the entire
+address space.
 . Traditionally, safe processors required the ability to remove or disable
 caches to ensure maximal predictability. Other solutions have emerged since,
 to avoid the drastic induced performance loss.
@@ -337,10 +338,10 @@ This functionality is platform defined (so may not be configurable for all or
 any memory regions), and it is not consistent with the intended use-model for
 PMA as described in the RISC-V Privileged ISA Specification
 cite:[rv-priv-spec:2024] Section 3.6:
-“PMAs are inherent properties of the underlying hardware and rarely change
+"PMAs are inherent properties of the underlying hardware and rarely change
 during system operation.
 Unlike Physical Memory Protection (PMP) values described in Section 3.7, PMAs
-do not vary by execution context”.
+do not vary by execution context".
 
 Standardized control and discovery mechanisms for TCM (and other memory
 architectures) can be considered.

--- a/src/chapters/caches.adoc
+++ b/src/chapters/caches.adoc
@@ -325,9 +325,9 @@ could be considered in future RISC-V specifications to embrace all approaches.
 Note that there are two standard ways to achieve this with current
 specifications, but both have significant drawbacks (there may also be
 implementation specific mechanisms):
-.. If the _Svpbmt_ (Page-Based Memory Types) extension is implemented, memory
-pages can be marked as non-cacheable in the page table, overriding the PMA
-attributes.
+.. If the [.extension]#Svpbmt# (Page-Based Memory Types) extension is
+implemented, memory pages can be marked as non-cacheable in the page table,
+overriding the PMA attributes.
 While in some situations this may be feasible, it either requires maintaining
 an alternate set of page tables, or updating existing page tables.
 It should be possible to activate or deactivate temporarily and temporally

--- a/src/chapters/pmc.adoc
+++ b/src/chapters/pmc.adoc
@@ -267,9 +267,10 @@ safety-related systems and then reviews specific uses through some examples.
 ##### Traceability to standards
 
 Performance Counters can be used as the basis for meeting safety requirements
-related to a variety of safety needs such as “freedom from interference”
-(ISO 26262 cite:[iso26262:2018]), “resource usage tests” (ISO 26262
-cite:[iso26262:2018]), and “interference channel characterization” (CAST 32-A cite:[cast32:2016]),
+related to a variety of safety needs such as "freedom from interference"
+(ISO 26262 cite:[iso26262:2018]), "resource usage tests" (ISO 26262
+cite:[iso26262:2018]), and "interference channel characterization"
+(CAST 32-A cite:[cast32:2016]),
 as well as for processes related to timing estimation, critical configuration
 setting validation and random hardware fault management.
 
@@ -418,8 +419,8 @@ In RV32 processors, they are accessed via two 32-bit CSRs for their LSB and MSB
 portions.
 
 The RISC-V Unprivileged ISA Specification cite:[rv-unpriv-spec:2024] (Chapter 8)
-defines with the *Zicntr* and *Zihpm* extensions an analogous facility for
-unprivileged hardware performance counters,
+defines with the [.extension]#Zicntr# and [.extension]#Zihpm# extensions an
+analogous facility for unprivileged hardware performance counters,
 including the Cycle Counter (`cycle`) CSR, the Instruction Retired Counter
 (`instret`) CSR and 29 additional Performance Monitoring Counters
 (`hpmcounter3` - `hpmcounter31`).
@@ -437,8 +438,8 @@ cite:[rv-priv-spec:2024] Sections 3.1.11 and 10.1.15, for machine and supervisor
 modes respectively).
 
 The RISC-V Privileged ISA Specification cite:[rv-priv-spec:2024] Chapter 17
-defines the *Sscofpmf* extension providing performance counters overflow and
-mode filtering capabilities for machine and supervisor modes.
+defines the [.extension]#Sscofpmf# extension providing performance counters
+overflow and mode filtering capabilities for machine and supervisor modes.
 The overflow capability allows the implementation of quotas as identified in the
 Features section of this chapter (<<sec:pmc:safety:features>>), while the mode filtering
 capabilities partially addresses the filtering capabilities identified in the
@@ -462,16 +463,17 @@ can be highlighted:
   specifying a family of events (i.e. events that have to be recorded at the
   same time) or specifying non-event conditions (i.e. counting the number of
   clock cycles for which a certain event does not occur).
-2. Filtering capabilities: the *Sscofpmf* extension provides mode-filtering
-  capabilities, nevertheless it would be desirable to provide other
-  event-filtering capabilities, such as comparison or edge detection, or the
-  initiator/target of the transaction (core ID for instance).
+2. Filtering capabilities: the [.extension]#Sscofpmf# extension provides
+  mode-filtering capabilities, nevertheless it would be desirable to provide
+  other event-filtering capabilities, such as comparison or edge detection, or
+  the initiator/target of the transaction (core ID for instance).
 3. Linked counters: it would be desirable to provide the capability of linking
   multiple counters, defining chains of events to be monitored.
 4. Quota allocation (see <<sec:pmc:safety:justification:uses:quota>> above):
   upon reaching the defined threshold, an interrupt would be triggered.
   An implementation would be to preload a value in the counter and trigger an
-  interrupt when the counter overflows as provided by the *Sscofpmf* extension.
+  interrupt when the counter overflows as provided by the [.extension]#Sscofpmf#
+  extension.
 5. Standardized event description: the description of events should be
   standardized as much as possible among the different RISC-V processor
   implementations.

--- a/src/chapters/pmc.adoc
+++ b/src/chapters/pmc.adoc
@@ -300,7 +300,7 @@ Without being exhaustive, this section identifies a number of uses of
 performance counters in the context of safety-relevant systems.
 
 [#sec:pmc:safety:justification:uses:wcet]
-###### Example 1: WCET estimation
+###### [.h4-example-heading]#Example 1: WCET estimation#
 
 Performance counters can be used for measurement-based timing analysis, or to
 feed some input data related to, for instance, latencies into static timing
@@ -317,7 +317,7 @@ In that case, performance counters can be used to feed timing models to find the
 best task scheduling in terms of timespan based on the timing model.
 
 [#sec:pmc:safety:justification:uses:valid]
-###### Example 2: resource usage validation and diagnostics
+###### [.h4-example-heading]#Example 2: resource usage validation and diagnostics#
 
 Performance counters can be used to measure accesses to different resources
 (e.g. peripheral devices, DRAM memory), as well as data transferred during the
@@ -335,7 +335,7 @@ specific resources are highly stressed and hence, whether consolidating
 additional applications may lead to resource overutilization.
 
 [#sec:pmc:safety:justification:uses:monitoring]
-###### Example 3: resource usage monitoring and diagnostics
+###### [.h4-example-heading]#Example 3: resource usage monitoring and diagnostics#
 
 As for example 2, performance counters can be used during operation analogously
 to the validation process, but to implement safety measures.
@@ -351,7 +351,7 @@ instance, if a task experiences overruns too frequently, switch to a different
 precomputed task schedule.
 
 [#sec:pmc:safety:justification:uses:quota]
-###### Example 4: quota allocation
+###### [.h4-example-heading]#Example 4: quota allocation#
 
 If performance counters allow programming quotas (e.g. maximum number of
 accesses or data transferred in a given resource), safety measures can be
@@ -365,7 +365,7 @@ ones, or drop other tasks if this one is highly critical and becomes more
 vulnerable to interference.
 
 [#sec:pmc:safety:justification:uses:faults]
-###### Example 5: management of random hardware faults
+###### [.h4-example-heading]#Example 5: management of random hardware faults#
 
 Performance counters related to errors detected and/or corrected may be used to
 detect intermittent and permanent faults.

--- a/src/wp-theme.yml
+++ b/src/wp-theme.yml
@@ -5,3 +5,4 @@ role:
     font-size: 1.17em # use the h3 size of the riscv-pdf theme
   extension:
     font-style: italic
+    

--- a/src/wp-theme.yml
+++ b/src/wp-theme.yml
@@ -1,0 +1,7 @@
+---
+extends: ../docs-resources/themes/riscv-pdf.yml
+role:
+  h4-example-heading:
+    font-size: 1.17em # use the h3 size of the riscv-pdf theme
+  extension:
+    font-style: italic

--- a/src/wp-theme.yml
+++ b/src/wp-theme.yml
@@ -5,4 +5,3 @@ role:
     font-size: 1.17em # use the h3 size of the riscv-pdf theme
   extension:
     font-style: italic
-    


### PR DESCRIPTION
This pull request extends the default RISC-V theming. The goal is not to extend the theming per se, but to allow the use of Asciidoc roles in the theme.
The commits add:

- New theme root file extending the RISC-V theme
- Add new role for level 4 section headings (h4) named `h4-example-heading`. It resizes the size of the header text (it was too small). This section header was used for examples in the Performance Counters Chapter.
- Add new role to uniform the typography of the extensions names. Sometimes they were in *italics*, sometimes **bold**. Using the role extension we can make all look the same, whatever we chose.
- Applied the extension role to extensions names in the Caches and Performance Counters chapters.