### PR TITLE
Fix multicore spelling

### DIFF
--- a/src/chapters/partitioning.adoc
+++ b/src/chapters/partitioning.adoc
@@ -80,7 +80,7 @@ advantages:
 * It also allows decreasing the risk of deadline overruns during operation since
   timing impacts  across different tasks are significantly decreased.
 
-On multi-core SOCs, time partitioning of tasks should be applied individually to
+On multicore SOCs, time partitioning of tasks should be applied individually to
 a single core as well as combinations of multiple cores.
 Time partitioning is key to allow tasks to start, with some degree of precision,
 when required, as well as to ensure they make sufficient progress to meet their
@@ -680,7 +680,7 @@ operations.
 
 In most cases, the mechanisms to partition resources other than memory are
 implementation-specific or located outside of the processor core (e.g. in the
-interconnect of multi-core systems) and not yet addressed by RISC-V
+interconnect of multicore systems) and not yet addressed by RISC-V
 specifications.
 
 For routing interrupts to a specific core, the Platform-Level Interrupt

--- a/src/chapters/pmc.adoc
+++ b/src/chapters/pmc.adoc
@@ -539,5 +539,5 @@ Such errors could be managed by an error management mechanism (related chapter
 to be released).
 
 SoC-level performance counters and monitoring are needed to implement some
-features identified to monitor the multi-core interference.
+features identified to monitor the multicore interference.
 Refer to xref:sec:partitioning[xrefstyle=full].

--- a/src/chapters/qos.adoc
+++ b/src/chapters/qos.adoc
@@ -90,9 +90,9 @@ xref:sec:pmc[xrefstyle=full].
 
 While QoS could be applied to single-core (and single-threaded) processors
 (e.g., for temperature concerns, or to manage interference across tasks running
-serially), it is particularly relevant for multi-core configurations where tasks
+serially), it is particularly relevant for multicore configurations where tasks
 run concurrently sharing hardware resources. Single-core concerns can be viewed
-as a (small) subset of multi-core concerns.
+as a (small) subset of multicore concerns.
 Hence, the level at which QoS is relevant is typically the SoC, with particular
 emphasis on the shared hardware resources.
 

--- a/src/fusa-whitepaper.adoc
+++ b/src/fusa-whitepaper.adoc
@@ -68,7 +68,7 @@ Attribution 4.0 International License (CC-BY 4.0). The full
 license text is available at
 https://creativecommons.org/licenses/by/4.0/.
 
-Copyright 2024 by RISC-V International.
+Copyright 2025 by RISC-V International.
 
 [preface]
 include::contributors.adoc[]


### PR DESCRIPTION
Replaced occurrences of "multi-core" with "multicore" to only use "multicore" all along the document.
"multicore" was chosen because that's the spelling used in "The RISC-V Instruction Set Manual Volume I - Unprivileged Architecture".

Also modified the copyright date from 2024 to 2025.