### PR TITLE
Adapt Makefile and root document to create document releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ DOCS := \
 
 DATE ?= $(shell date +%Y-%m-%d)
 VERSION ?= v0.0.0
-REVMARK ?= Draft
+# Leaving the REVMARK unset will put the document in draft state and the
+# background of the document will have a "DRAFT" image.
+REVMARK ?=
 DOCKER_IMG := riscvintl/riscv-docs-base-container-image:latest
 ifneq ($(SKIP_DOCKER),true)
   DOCKER_IS_PODMAN = \
@@ -49,7 +51,6 @@ OPTIONS := --trace \
   -a compress \
   -a mathematical-format=svg \
   -a revnumber=${VERSION} \
-  -a revremark=${REVMARK} \
   -a revdate=${DATE} \
   -a imagesoutdir=${BUILD_DIR}/images \
   -a pdf-fontsdir=docs-resources/fonts \
@@ -57,6 +58,9 @@ OPTIONS := --trace \
   $(XTRA_ADOC_OPTS) \
   -D ${BUILD_DIR} \
   --failure-level=ERROR
+ifneq (${REVMARK},)
+OPTIONS := ${OPTIONS} -a revremark=${REVMARK}
+endif
 REQUIRES := --require=asciidoctor-bibtex \
   --require=asciidoctor-diagram \
   --require=asciidoctor-lists \

--- a/src/fusa-whitepaper.adoc
+++ b/src/fusa-whitepaper.adoc
@@ -5,7 +5,11 @@ include::../docs-resources/global-config.adoc[]
 :description: RISC-V Functional Safety Whitepaper
 :revdate: 11/2024
 :revnumber: 1.0
-:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.
+ifndef::revremark[]
+:revremark: This document is under development. Expect potential changes.
+// Visit http://riscv.org/spec-state for further details.
+:page-background-image: image:docs-resources/images/draft.png[]
+endif::[]
 :revinfo:
 :preface-title: Preamble
 :colophon:
@@ -40,7 +44,6 @@ endif::[]
 :stem: latexmath
 :footnote:
 :xrefstyle: short
-:page-background-image: image:docs-resources/images/draft.png[]
 
 [preface]
 == List of figures


### PR DESCRIPTION
When running make without the REVMARK flag the document will be created in draft mode, where a default release text will be used and a DRAFT image will be put in the background of every page.

For creating a release of the document run make with REVMARK set up. Typically this will be done when the document version number will be also defined.
For example:
```
VERSION="v1.0.2" REVMARK="Release\ (update)." make
```
Make sure to escape spaces, like in the example above.