### PR TITLE
Remove comment in glossary that appeared in the produced document

### DIFF
--- a/src/chapters/intro/glossary.adoc
+++ b/src/chapters/intro/glossary.adoc
@@ -134,12 +134,3 @@ operating systems, by allowing them to run on the same host hardware.
   execute.
 
 |===
-
-[WARNING]
-.Other possible terms
-====
-Do we need to add the following terms to the glossary:
-
-* RCID/MCID
-
-====


### PR DESCRIPTION
Removed editorial comment in the glossary section that appeared on the built document.