### PR TITLE
"whitepaper" to "white paper"

### DIFF
--- a/src/chapters/intro.adoc
+++ b/src/chapters/intro.adoc
@@ -98,7 +98,7 @@ accuracy of this document.
 // Current chapters.
 // =============================================================================
 // =============================================================================
-This whitepaper currently includes chapters for the following topics:
+This white paper currently includes chapters for the following topics:
 
 * Caches and tightly coupled memories (TCM), see <<sec:caches>>;
 * Performance counters, see <<sec:pmc>>;

--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -1,6 +1,6 @@
 == Contributors
 
-This whitepaper has been contributed to directly or indirectly by:
+This white paper has been contributed to directly or indirectly by:
 Jaume Abella (Barcelona Supercomputing Center),
 Sergi Alcaide Portet (Barcelona Supercomputing Center),
 Verena Beckham (Qualcomm),

--- a/src/fusa-whitepaper.adoc
+++ b/src/fusa-whitepaper.adoc
@@ -1,4 +1,4 @@
-= Functional Safety Whitepaper
+= Functional Safety White Paper
 Editors: Jérôme Quévremont (Thales), Amit Pabalkar (NVIDIA Corporation), Jaume Abella (Barcelona Supercomputing Center), Daniel Gracia Pérez (Thales)
 include::../docs-resources/global-config.adoc[]
 :docgroup: RISC-V Functional Safety Special Interest Group
@@ -66,7 +66,7 @@ it is accepted for publication. Citation test: RISC-V Unprivileged Specification
 
 [preface]
 == Copyright and license information
-This whitepaper is licensed under the Creative Commons
+This white paper is licensed under the Creative Commons
 Attribution 4.0 International License (CC-BY 4.0). The full
 license text is available at
 https://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
"whitepaper" and "white paper" were used in the document. Move all occurrences to "white paper" which seems to the good spelling, even if "whitepaper" is accepted.